### PR TITLE
Add Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
 sudo: false
-script:
-- bundle exec rspec
-- bundle exec rubocop
+script: bundle exec rake
 dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+sudo: false
+script:
+- bundle exec rspec
+- bundle exec rubocop
+dist: trusty

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'scraperwiki', git: 'https://github.com/openaustralia/scraperwiki-ruby.git',
 
 group :development do
   gem 'pry'
+  gem 'rake'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,7 @@ DEPENDENCIES
   mechanize
   octokit (~> 4.0)
   pry
+  rake
   rest-client
   rspec
   rubocop

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rubocop/rake_task'
+require 'rspec/core/rake_task'
+
+RuboCop::RakeTask.new(:rubocop) do |t|
+  t.options = ['--display-cop-names']
+end
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: %i[spec rubocop]


### PR DESCRIPTION
So we [can do CI](https://travis-ci.org/openaustralia/jacaranda) on all changes to Jacaranda. 

This is good because:

- Tests are visible to everyone
- Tests are automatically run on PRs
- Folks merging PRs know if they're going to break things
