### PR TITLE
Track posts to Slack in new table. Fixes #15.

### DIFF
--- a/lib/jacaranda.rb
+++ b/lib/jacaranda.rb
@@ -20,22 +20,22 @@ module Jacaranda
   end
 
   def self.upgrade_schema!
-    return if has_been_migrated?
-    data = ScraperWiki.select("* from data")
-    upgraded = data.map {|r| r['runner'] = 'RightToKnow::Runner' unless r['runner'] ; r }
+    return if been_migrated?
+    data = ScraperWiki.select('* from data')
+    upgraded = data.each { |r| r['runner'] = 'RightToKnow::Runner' unless r['runner'] }
     primary_keys = %w[date_posted runner]
     table_name = 'posts'
     ScraperWiki.save_sqlite(primary_keys, upgraded, table_name)
   end
 
-  def self.has_been_migrated?
-    query = %[SELECT sql FROM sqlite_master where name = 'data' AND type = 'table']
+  def self.been_migrated?
+    query = %(SELECT sql FROM sqlite_master where name = 'data' AND type = 'table')
     return true if ScraperWiki.sqliteexecute(query).empty?
 
-    query = %[SELECT sql FROM sqlite_master where name = 'posts' AND type = 'table']
+    query = %(SELECT sql FROM sqlite_master where name = 'posts' AND type = 'table')
     return true if ScraperWiki.sqliteexecute(query).any?
 
-    return false
+    false
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/lib/jacaranda.rb
+++ b/lib/jacaranda.rb
@@ -29,8 +29,13 @@ module Jacaranda
   end
 
   def self.has_been_migrated?
+    query = %[SELECT sql FROM sqlite_master where name = 'data' AND type = 'table']
+    return true if ScraperWiki.sqliteexecute(query).empty?
+
     query = %[SELECT sql FROM sqlite_master where name = 'posts' AND type = 'table']
-    !ScraperWiki.sqliteexecute(query).empty?
+    return true if ScraperWiki.sqliteexecute(query).any?
+
+    return false
   end
 
   # rubocop:disable Metrics/MethodLength

--- a/lib/runners/base_runner.rb
+++ b/lib/runners/base_runner.rb
@@ -34,7 +34,7 @@ module Jacaranda
       end
 
       def posts
-        posts = ScraperWiki.select("* from data where runner = '#{self}'")
+        posts = ScraperWiki.select("* from posts where runner = '#{self}'")
         normalise_dates(posts)
       rescue
         []
@@ -110,7 +110,7 @@ module Jacaranda
           text: message,
           runner: to_s
         }
-        ScraperWiki.save_sqlite(%i[date_posted runner], record)
+        ScraperWiki.save_sqlite(%i[date_posted runner], record, 'posts')
       end
 
       def print(message)

--- a/scraper.rb
+++ b/scraper.rb
@@ -2,6 +2,6 @@
 
 require 'dotenv'
 Dotenv.load
-require_relative 'lib/runners'
+require_relative 'lib/jacaranda'
 
 Jacaranda.run(ARGV) if $PROGRAM_NAME == __FILE__

--- a/spec/jacaranda_spec.rb
+++ b/spec/jacaranda_spec.rb
@@ -14,9 +14,9 @@ describe 'Jacaranda' do
   describe '.upgrade_schema!' do
     let(:insert_data_statements) do
       [
-        %[INSERT INTO data (date_posted,text,runner) VALUES ('2016-08-29','hello',null)],
-        %[INSERT INTO data (date_posted,text,runner) VALUES ('2016-09-12','world',null)],
-        %[INSERT INTO data (date_posted,text,runner) VALUES ('2017-09-04','foo','RightToKnow::Runner')],
+        %(INSERT INTO data (date_posted,text,runner) VALUES ('2016-08-29','hello',null)),
+        %(INSERT INTO data (date_posted,text,runner) VALUES ('2016-09-12','world',null)),
+        %(INSERT INTO data (date_posted,text,runner) VALUES ('2017-09-04','foo','RightToKnow::Runner'))
       ]
     end
 
@@ -25,7 +25,7 @@ describe 'Jacaranda' do
       insert_data_statements.each { |statement| ScraperWiki.sqliteexecute(statement) }
     end
 
-    context 'when the schema is old' do
+    context 'when the schema has not been upgraded' do
       let(:create_table_statements) do
         [
           %[CREATE TABLE data (date_posted,text,runner,UNIQUE (date_posted))]
@@ -33,26 +33,26 @@ describe 'Jacaranda' do
       end
 
       it 'applies the upgrade' do
-        expect(Jacaranda.has_been_migrated?).to be false
+        expect(Jacaranda.been_migrated?).to be false
         Jacaranda.upgrade_schema!
-        expect(Jacaranda.has_been_migrated?).to be true
+        expect(Jacaranda.been_migrated?).to be true
 
-        query = %[SELECT sql FROM sqlite_master WHERE name = 'posts' AND type = 'table']
+        query = %(SELECT sql FROM sqlite_master WHERE name = 'posts' AND type = 'table')
         expect(ScraperWiki.sqliteexecute(query).any?).to be true
 
-        query = %[SELECT count(*) AS count FROM posts]
+        query = %(SELECT count(*) AS count FROM posts)
         expect(ScraperWiki.sqliteexecute(query).first['count']).to eq(insert_data_statements.size)
 
-        query = %[SELECT * FROM posts WHERE runner IS NULL]
+        query = %(SELECT * FROM posts WHERE runner IS NULL)
         expect(ScraperWiki.sqliteexecute(query).empty?).to be true
       end
     end
 
-    context 'when the schema is new' do
+    context 'when the schema has been upgraded' do
       let(:create_table_statements) do
         [
           %[CREATE TABLE data (date_posted,text,runner,UNIQUE (date_posted))],
-          %[CREATE TABLE posts (date_posted,text,runner,UNIQUE (date_posted,runner))],
+          %[CREATE TABLE posts (date_posted,text,runner,UNIQUE (date_posted,runner))]
         ]
       end
 

--- a/spec/runners/base_runner_spec.rb
+++ b/spec/runners/base_runner_spec.rb
@@ -77,7 +77,7 @@ describe 'Jacaranda' do
         end
       end
 
-      after(:each) { ScraperWiki.sqliteexecute('DELETE FROM data') }
+      after(:each) { ScraperWiki.sqliteexecute('DELETE FROM posts') }
     end
 
     describe '.run' do
@@ -109,7 +109,7 @@ describe 'Jacaranda' do
 
       after(:each) do
         restore_env
-        ScraperWiki.sqliteexecute('DELETE FROM data')
+        ScraperWiki.sqliteexecute('DELETE FROM posts')
       end
     end
 


### PR DESCRIPTION
This PR:

 - Changes the scraper to use a new table for recording runs called `posts`.
 - Adds logic to backfill data into the new table on first load.

Fixes #15.